### PR TITLE
Agent action extension/vocabs from the TDWG Attribution group

### DIFF
--- a/sandbox/extension/agent_actions_v2020-09-08.xml
+++ b/sandbox/extension/agent_actions_v2020-09-08.xml
@@ -25,7 +25,7 @@
         required="true"/>
     <property
         name="agentIdentifierType"
-        thesaurus="https://tdwg.github.io/attribution/people/dwc/vocubulary/agentIdentifierType.xml"
+        thesaurus="http://rs.gbif.org/sandbox/vocabulary/tdwg/agentIdentifierType.xml"
         namespace="https://tdwg.github.io/attribution/people/dwc/terms/"
         qualName="https://tdwg.github.io/attribution/people/dwc/terms/agentIdentifierType"
         dc:description="The type of identifier for the agent. Recommended best practice is to use a controlled vocabulary."
@@ -74,7 +74,7 @@
         required="false"/>
     <property
         name="action"
-        thesaurus="https://tdwg.github.io/attribution/people/dwc/vocubulary/action.xml"
+        thesaurus="http://rs.gbif.org/sandbox/vocabulary/tdwg/action.xml"
         namespace="https://tdwg.github.io/attribution/people/dwc/terms/"
         qualName="https://tdwg.github.io/attribution/people/dwc/terms/action"
         dc:description="The name of the single action written as a verb in past tense. Recommended best practice is to use a controlled vocabulary."
@@ -83,7 +83,7 @@
         required="true"/>
     <property
         name="role"
-        thesaurus="https://tdwg.github.io/attribution/people/dwc/vocubulary/role.xml"
+        thesaurus="http://rs.gbif.org/sandbox/vocabulary/tdwg/role.xml"
         namespace="https://tdwg.github.io/attribution/people/dwc/terms/"
         qualName="https://tdwg.github.io/attribution/people/dwc/terms/role"
         dc:description="The name of the role the agent played in the context of executing the action. Not to be confused with the agent's role in an organization. Recommended best practice is to use a controlled vocabulary."

--- a/sandbox/extension/agent_actions_v2020-09-08.xml
+++ b/sandbox/extension/agent_actions_v2020-09-08.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/style/human.xsl"?>
+<extension xmlns="http://rs.gbif.org/extension/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:dc="http://purl.org/dc/terms/"
+    xmlns:dwc="http://rs.tdwg.org/dwc/terms/"
+    xmlns:sch="http://schema.org/"
+    xmlns:gvp="http://vocab.getty.edu/ontology/"
+    xsi:schemaLocation="http://rs.gbif.org/extension/ http://rs.gbif.org/schema/extension.xsd"
+    dc:title="AgentActions"
+    name="AgentActions"
+    namespace="https://tdwg.github.io/attribution/people/dwc/"
+    rowType="https://tdwg.github.io/attribution/people/dwc/AgentActions"
+    dc:issued="2020-09-08"
+    dc:description="Extension to Occurrence Core to capture agents and optionally the specific roles they played in the context of executing actions on occurrences."
+    dc:relation=""
+    dc:subject="dwc:Occurrence">
+    <property
+        name="type"
+        namespace="http://purl.org/dc/terms/"
+        qualName="http://purl.org/dc/terms/type"
+        dc:description="The nature or genre of the resource. Recommended practice is to use a controlled vocabulary."
+        examples='"http://schema.org/Person", "http://schema.org/Organization"'
+        type="string"
+        required="true"/>
+    <property
+        name="agentIdentifierType"
+        thesaurus="https://tdwg.github.io/attribution/people/dwc/vocubulary/agentIdentifierType.xml"
+        namespace="https://tdwg.github.io/attribution/people/dwc/terms/"
+        qualName="https://tdwg.github.io/attribution/people/dwc/terms/agentIdentifierType"
+        dc:description="The type of identifier for the agent. Recommended best practice is to use a controlled vocabulary."
+        examples='"ORCID", "ISNI", "Wikidata", "VIAF", "RoR", "Ringgold", "GRID"'
+        type="string"
+        required="false"/>
+    <property
+        name="identifier"
+        namespace="http://purl.org/dc/terms/"
+        qualName="http://purl.org/dc/terms/identifier"
+        dc:description="Recommended practice is to identify the resource by means of a string conforming to an identification system. Examples include International Standard Book Number (ISBN), Digital Object Identifier (DOI), and Uniform Resource Name (URN). Persistent identifiers should be provided as HTTP URIs."
+        examples="https://orcid.org/0000-0001-6201-7340"
+        type="string"
+        required="false"/>
+    <property
+        name="name"
+        namespace="https://schema.org/"
+        qualName="https://schema.org/name"
+        dc:description="The name of the item. In this case the full name as woud be written on a legal document (without abbreviation), eg givenName familyName"
+        examples="Margaret Smith"
+        type="string"
+        required="true"/>
+    <property
+        name="additionalName"
+        namespace="https://schema.org/"
+        qualName="https://schema.org/additionalName"
+        dc:description="An additional name for a Person, can be used for a middle name."
+        examples="Anne"
+        type="string"
+        required="false"/>
+    <property
+        name="alternateName"
+        namespace="https://schema.org/"
+        qualName="https://schema.org/alternateName"
+        dc:description="An alias for the item. Other full name agent may have been known under such as maiden name."
+        examples="Margaret Johnson"
+        type="string"
+        required="false"/>
+    <property
+        name="verbatimName"
+        namespace="https://tdwg.github.io/attribution/people/dwc/terms/"
+        qualName="https://tdwg.github.io/attribution/dwc/terms/verbatimName"
+        dc:description="As written on occurrence, such as the collection or determination label."
+        examples="MC Smith"
+        type="string"
+        required="false"/>
+    <property
+        name="action"
+        thesaurus="https://tdwg.github.io/attribution/people/dwc/vocubulary/action.xml"
+        namespace="https://tdwg.github.io/attribution/people/dwc/terms/"
+        qualName="https://tdwg.github.io/attribution/people/dwc/terms/action"
+        dc:description="The name of the single action written as a verb in past tense. Recommended best practice is to use a controlled vocabulary."
+        examples='"collected","identified"'
+        type="string"
+        required="true"/>
+    <property
+        name="role"
+        thesaurus="https://tdwg.github.io/attribution/people/dwc/vocubulary/role.xml"
+        namespace="https://tdwg.github.io/attribution/people/dwc/terms/"
+        qualName="https://tdwg.github.io/attribution/people/dwc/terms/role"
+        dc:description="The name of the role the agent played in the context of executing the action. Not to be confused with the agent's role in an organization. Recommended best practice is to use a controlled vocabulary."
+        examples='"major-effort","participant"'
+        type="string"
+        required="false"/>
+    <property
+        name="displayOrder"
+        namespace="http://vocab.getty.edu/ontology/"
+        qualName="http://vocab.getty.edu/ontology/displayOrder"
+        dc:description="The display order for the agent that executed the action when more than one agent was a participant."
+        examples='1'
+        type="integer"
+        required="false"/>
+    <property
+        name="identificationID"
+        namespace="http://rs.tdwg.org/dwc/terms/"
+        qualName="http://rs.tdwg.org/dwc/terms/identificationID"
+        dc:description="An identifier for the Identification (the body of information associated with the assignment of a scientific name). May be a global unique identifier or an identifier specific to the data set. The intent of this term is to maintain the relational integrity between the identified action and a particular determination/annotation expressed in the Identification History Extension when present."
+        examples='9992'
+        type="string"
+        required="false"/>
+    <property
+        name="startedAtTime"
+        namespace="http://www.w3.org/ns/prov#"
+        qualName="http://www.w3.org/ns/prov#startedAtTime"
+        dc:description="Start is when an activity is deemed to have been started by an entity."
+        examples="2012-04-25T01:30:00Z"
+        type="date"
+        required="false"/>
+     <property
+         name="endedAtTime"
+         namespace="http://www.w3.org/ns/prov#"
+         qualName="http://www.w3.org/ns/prov#endedAtTime"
+         dc:description="End is when an activity is deemed to have been ended by an entity."
+         examples="2012-04-25T03:40:00Z"
+         type="date"
+         required="false"/>
+</extension>

--- a/sandbox/vocabulary/tdwg/action.xml
+++ b/sandbox/vocabulary/tdwg/action.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thesaurus
+  dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/"
+  dc:description="Vocabulary of actions executed by agents on occurrences"
+  dc:relation=""
+  dc:title="AgentActions action vocabulary"
+  dc:issued="2020-05-18"
+  xmlns="http://rs.gbif.org/thesaurus/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://rs.gbif.org/thesaurus/  http://rs.gbif.org/schema/thesaurus.xsd">
+
+  <concept dc:identifier="collected" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/collected" dc:relation="" dc:description="Collected the subject">
+    <preferred>
+      <term dc:title="collected" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="identified" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/identified" dc:relation="" dc:description="Assigned the subject to a taxon">
+    <preferred>
+      <term dc:title="identified" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="verified" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/verified" dc:relation="" dc:description="Assigned the subject to a taxon in concordance with a prior determination.">
+    <preferred>
+      <term dc:title="verified" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+    <concept dc:identifier="observed" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/observed" dc:relation="" dc:description="Observed the subject">
+    <preferred>
+      <term dc:title="observed" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="prepared" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/prepared" dc:relation="" dc:description="Prepared the subject">
+    <preferred>
+      <term dc:title="prepared" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="georeferenced" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/georeferenced" dc:relation="" dc:description="Determined the georeference (spatial representation) for the location">
+    <preferred>
+      <term dc:title="georeferenced" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="measured" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/measured" dc:relation="" dc:description="Determined the value of a measurement">
+    <preferred>
+      <term dc:title="measured" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="transcribed" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/action/transcribed" dc:relation="" dc:description="Put written text on the object to a digital form">
+    <preferred>
+      <term dc:title="transcribed" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+</thesaurus>

--- a/sandbox/vocabulary/tdwg/agentIdentifierType.xml
+++ b/sandbox/vocabulary/tdwg/agentIdentifierType.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thesaurus
+  dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/agentIdentifierType/"
+  dc:description="Vocabulary of identifier types for agents that executed actions on occurrences"
+  dc:relation=""
+  dc:title="AgentActions identifierType vocabulary"
+  dc:issued="2020-05-18"
+  xmlns="http://rs.gbif.org/thesaurus/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://rs.gbif.org/thesaurus/  http://rs.gbif.org/schema/thesaurus.xsd">
+
+  <concept dc:identifier="ORCID" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/agentIdentifierType/ORCID" dc:relation="" dc:description="Open Researcher and Contributor ID (ORCID), https://orcid.org/">
+    <preferred>
+      <term dc:title="ORCID" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="VIAF" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/agentIdentifierType/VIAF" dc:relation="" dc:description="Virtual International Authority File (VIAF), https://viaf.org/">
+    <preferred>
+      <term dc:title="VIAF" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="ISNI" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/agentIdentifierType/ISNI" dc:relation="" dc:description="International Standard Name Identifier (ISNI), http://www.isni.org/">
+    <preferred>
+      <term dc:title="ISNI" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="GRID" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/agentIdentifierType/GRID" dc:relation="" dc:description="Global Research Identifier Database (GRID), https://www.grid.ac/">
+    <preferred>
+      <term dc:title="GRID" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="ringgold" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/agentIdentifierType/ringgold" dc:relation="" dc:description="Ringgold Identify Database, https://www.ringgold.com/">
+    <preferred>
+      <term dc:title="ringgold" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="RoR" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/agentIdentifierType/RoR" dc:relation="" dc:description="Research Organization Registry (RoR), https://ror.org/">
+    <preferred>
+      <term dc:title="RoR" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="wikidata" dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/agentIdentifierType/wikidata" dc:relation="" dc:description="Wikidata QID, https://www.wikidata.org/">
+    <preferred>
+      <term dc:title="wikidata" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+</thesaurus>

--- a/sandbox/vocabulary/tdwg/role.xml
+++ b/sandbox/vocabulary/tdwg/role.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thesaurus
+  dc:URI="https://tdwg.github.io/attribution/people/dwc/vocabulary/role/"
+  dc:description="Vocabulary to represent an agent's role within the context of the specific action."
+  dc:relation="http://purl.obolibrary.org/obo/cro.owl"
+  dc:title="AgentActions role vocabulary"
+  dc:issued="2020-05-18"
+  xmlns="http://rs.gbif.org/thesaurus/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://rs.gbif.org/thesaurus/  http://rs.gbif.org/schema/thesaurus.xsd">
+
+  <concept dc:identifier="CRO_0000094" dc:URI="http://purl.obolibrary.org/obo/CRO_0000094" dc:relation="" dc:description="In botany, this is the collector listed first for a particular specimen. Each specimen has one primary collector. The primary collector assigns a number to that specimen from his/her own number series.">
+    <preferred>
+      <term dc:title="primary collector role" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+  <concept dc:identifier="CRO_0000093" dc:URI="http://purl.obolibrary.org/obo/CRO_0000093" dc:relation="" dc:description="Obtaining a material entity for potential use as an input during an investigation.">
+    <preferred>
+      <term dc:title="specimen collection role" xml:lang="en"/>
+    </preferred>
+    <alternative>
+    </alternative>
+  </concept>
+
+</thesaurus>


### PR DESCRIPTION
This should bring the Agent Action extension and the associated vocabularies into the sandbox for demonstration and review by the TDWG Attribution group.