### PR TITLE
Change type to agentType

### DIFF
--- a/sandbox/extension/agent_actions_v2020-09-08.xml
+++ b/sandbox/extension/agent_actions_v2020-09-08.xml
@@ -16,10 +16,10 @@
     dc:relation=""
     dc:subject="dwc:Occurrence">
     <property
-        name="type"
-        namespace="http://purl.org/dc/terms/"
-        qualName="http://purl.org/dc/terms/type"
-        dc:description="The nature or genre of the resource. Recommended practice is to use a controlled vocabulary."
+        name="agentType"
+        namespace="https://tdwg.github.io/attribution/people/dwc/terms/"
+        qualName="https://tdwg.github.io/attribution/people/dwc/terms/agentType"
+        dc:description="The nature of the agent. Recommended practice is to use a controlled vocabulary."
         examples='"http://schema.org/Person", "http://schema.org/Organization"'
         type="string"
         required="true"/>


### PR DESCRIPTION
`dc:type` does not contain any terms in its controlled vocabulary that we need here. Based on discussion at https://github.com/tdwg/attribution/issues/14, recommend using `agentType` instead of `dc:type`.