### PR TITLE
HTML extensions list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.asis
 extensions.html
 extensions.json
 sandbox/extensions.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+extensions.html
 extensions.json
+sandbox/extensions.html
 sandbox/extensions.json
+sandbox/vocabularies.html
 sandbox/vocabularies.json
+vocabularies.html
 vocabularies.json
-.DS_Store

--- a/extension/gbif/1.0/distribution_2022-02-02.xml
+++ b/extension/gbif/1.0/distribution_2022-02-02.xml
@@ -8,7 +8,7 @@
     dc:title="Species Distribution" name="Distribution" namespace="http://rs.gbif.org/terms/1.0"
     dc:issued="2022-02-02"
     dc:subject="dwc:Taxon"
-    dc:relation="http://rs.gbif.org/extension/gbif/1.0/distribution.xml"
+    dc:relation="http://rs.gbif.org/extension/gbif/1.0/distribution_2022-02-02.xml"
     dc:description="Geographic distribution of a taxon.  Replaces version issued 2020-07-15 with establishmentMeans, degreeOfEstablishment and pathway properties and vocabularies.">
 
     <property name='locationID' namespace='http://rs.tdwg.org/dwc/terms/' qualName='http://rs.tdwg.org/dwc/terms/locationID' dc:relation='http://rs.gbif.org/areas/' dc:description='A code for the named area this distributon record is about. Use a prefix for each code to indicate the source of the code, see http://rs.gbif.org/areas/ for list of coding schemes and their recommended prefix.' examples='TDWG:AGS-TF; ISO:AR; WOEID:564721' required='false'/>

--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
             <h1>Repository of Schemas</h1>
         </header>
 
-        <p>This site contains technical GBIF resources like XML schemas, Darwin Core Archive/IPT extensions and vocabularies and is primarily intended for machine reading.</p>
-        <p>Some documents feature human renderings via XSLT for browsers capable of processing these.</p>
+        <p>This site contains technical GBIF resources including XML schemas, Darwin Core Archive/IPT extensions and vocabularies.</p>
 
         <ul>
+            <li><strong><a href="extensions.html">Darwin Core Archive — current cores and extensions</a></strong></li>
             <li><a href="core/">Darwin Core Archive — Core Definitions</a></li>
             <li><a href="extension/">Darwin Core Archive — Extension Definitions</a></li>
             <li><a href="terms/">Darwin Core Archive — Term Definitions</a></li>

--- a/style/human.css
+++ b/style/human.css
@@ -9,14 +9,14 @@
 
 html {
 	color: #333;
-	font-family: Helvetica, Arial, Geneva, sans-serif;
+	font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	background-color: #ffffff;
 	background-image: url("data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' xmlns%3Axlink%3D'http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink'%0D%0A  viewBox%3D'0 0 476.24922 237.20944' height%3D'237.20944' width%3D'476.24921' version%3D'1.1' id%3D'svg2'%3E%0D%0A %3Cg id%3D'logo' transform%3D'translate(-1.3637789%2C1.4287109e-5)' style%3D'fill%3A%2347a138%3Bfill-opacity%3A0.05%3Bstroke%3Anone'%3E%0D%0A %3Cpath d%3D'm 96.631234%2C107.59128 c 0%2C-42.597997 20.789506%2C-79.462997 82.647876%2C-79.462997 0%2C42.69 -28.08125%2C79.462997 -82.647876%2C79.462997' %2F%3E%0D%0A %3Cpath d%3D'm 195.74161%2C219.43703 c 11.58625%2C0 20.49125%2C-1.64892 29.6375%2C-5.01368 0%2C-33.71244 -20.11125%2C-57.80269 -55.635%2C-75.16107 -27.185%2C-13.63337 -60.64462%2C-20.691 -91.159751%2C-20.691 13.389625%2C-40.189247 3.629875%2C-90.056747 -9.34625%2C-117.430497 -14.375875%2C28.6775 -23.349125%2C77.8425 -9.545375%2C117.842127 -27.106875%2C1.97662 -48.603025%2C13.78425 -57.6977496%2C29.354 -0.6870075%2C1.1875 -2.06298503%2C3.71875 -1.23974253%2C4.15137 0.64795003%2C0.34762 1.69678003%2C-0.71237 2.34473003%2C-1.30375 9.7944251%2C-9.06737 22.7636371%2C-13.48475 35.2153871%2C-13.48475 28.77725%2C0 49.09275%2C23.88075 63.446751%2C38.2275 30.8495%2C30.84613 61.002%2C43.57371 93.9795%2C43.50975' %2F%3E%0D%0A  %3C%2Fg%3E%0D%0A  %3Cuse x%3D'0' y%3D'0' xlink%3Ahref%3D'%23logo' transform%3D'translate(245.87887%2C-108)' width%3D'100%25' height%3D'100%25' %2F%3E%0D%0A  %3Cuse x%3D'0' y%3D'0' xlink%3Ahref%3D'%23logo' transform%3D'translate(245.87887%2C129.20944)' width%3D'100%25' height%3D'100%25' %2F%3E%0D%0A%3C%2Fsvg%3E");
 	background-position: 50% 0;
 }
 
 body {
-	margin: 3em auto;
+	margin: 4em auto 1em;
 	padding: 0 3em;
 }
 
@@ -34,11 +34,7 @@ a:hover {
 	color: rgb(0, 84, 24);
 }
 
-header img {
-	display: block;
-}
-
-h1, h2 {margin:15px 0 10px 0;}
+h1, h2 {margin:15px 0 15px 0;}
 h3, h4, h5, h6 {margin:5px 0 10px 0;}
 h1 {font-size:260%; font-weight:normal; letter-spacing:-1px;}
 h2 {font-size:160%; font-weight:normal;}
@@ -72,19 +68,63 @@ legend {position:absolute; top:-1em; margin:0; padding:5px 10px; font-size:100%;
 
 /* @end */
 
-
 /* @group LAYOUT */
 header {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	margin: 3em auto;
+	margin: 2em auto;
 }
 header * {
 	padding: 0 0.25em;
 }
-#header {
+header h1, header h2 {
 	text-align: center;
+	margin: 0;
+}
+header img {
+	display: block;
+}
+
+/* @end */
+
+/* @group NAV */
+nav {
+	display: block;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 2.75em;
+	background: #686a68;
+	color: white;
+}
+
+nav ul {
+	display: flex;
+	height: 2.75em;
+	align-items: center;
+	gap: 1em;
+	margin-top: 0;
+	margin-bottom: 0;
+	padding: 0 0 0 0.5em;
+	list-style-type: none;
+}
+
+nav ul li {
+	margin-top: 0;
+	margin-bottom: 0;
+	padding: 0;
+}
+
+nav a {
+	display: block;
+	color: white;
+}
+
+nav a, nav a:hover {
+	display: block;
+	color: white;
 }
 
 /* @end */

--- a/style/human.xsl
+++ b/style/human.xsl
@@ -7,7 +7,6 @@
      xmlns:voc="http://rs.gbif.org/thesaurus/"
      xmlns="http://www.w3.org/1999/xhtml">
 
-
      <xsl:output method="html" encoding="UTF-8" indent="yes"/>
      <xsl:template match="/*">
           <xsl:variable name="defType">
@@ -18,20 +17,25 @@
           </xsl:variable>
           <html>
                <head>
-                    <title><xsl:value-of select="@dc:title"/> - <xsl:value-of select="$defType"/></title>
+                    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+                    <title><xsl:value-of select="@dc:title"/> – <xsl:value-of select="$defType"/></title>
                     <link rel="stylesheet" type="text/css" href="/style/human.css"/>
                </head>
                <body>
-                    <div class="container">
-                         <div id="header" class="box">
-                              <h2 id="logo">
-                                   <img src="/style/logo-gbif.svg" width="115" height="46"/>
-                                   Darwin Core <xsl:value-of select="$defType"/>
-                                   <span style="font-size:60%;color:#888;"> (<a href="/">index</a>)</span>
-                              </h2>
+                    <nav>
+                         <ul>
+                              <li><img src="/style/logo-gbif-white.svg" width="67" height="28"/></li>
+                              <li><a href="/">Repository of Schemas</a></li>
+                         </ul>
+                    </nav>
+                    <header>
+                         <img src="/style/logo-gbif.svg" width="115" height="46"/>
+                         <div>
+                              <h2>Darwin Core <xsl:value-of select="$defType"/></h2>
                               <h1><xsl:value-of select="@dc:title"/></h1>
                          </div>
-
+                    </header>
+                    <div class="container">
                          <div id="content">
                               <table class="nice">
                                    <tr>

--- a/style/index_header.html
+++ b/style/index_header.html
@@ -4,9 +4,14 @@
         <link rel="stylesheet" type="text/css" href="/style/human.css"/>
     </head>
     <body>
+        <nav>
+            <ul>
+                <li><img src="/style/logo-gbif-white.svg" width="67" height="28"/></li>
+                <li><a href="/">Repository of Schemas</a></li>
+            </ul>
+        </nav>
         <header>
             <img src="/style/logo-gbif.svg" width="115" height="46"/>
             <h1>Resources</h1>
         </header>
-        <p><a href="http://rs.gbif.org/">Resource index</a></p>
         <div id="content">

--- a/sync-extensions.py
+++ b/sync-extensions.py
@@ -1,32 +1,34 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+#
+# Registry Updater for extensions and vocabularies
+#
 
-# ****************************************
-# +++  Registry Updater for
-# +++  Extensions and Vocabularies
-# ****************************************
-
-import sys, string, urllib, traceback, os, json, datetime
+import datetime
+import json
+import os
+import sys
+import traceback
+import urllib.request
 from xml.etree.ElementTree import ElementTree
-from urllib import FancyURLopener
 
 RS_BASE=os.getcwd()+"/"
 NS_DC="http://purl.org/dc/terms/"
 NS_EXT="http://rs.gbif.org/extension/"
-# default issued date 
+# default issued date
 MIN_DATE = datetime.date(datetime.MINYEAR, 1, 1)
 
 class Extension:
   def __init__(self):
-    self.identifier=None
+    self.identifier = None
     self.url = None
     self.title = None
     self.description = None
     self.subject = None
-    self.issued=None
-    self.isLatest=False
+    self.issued = None
+    self.isLatest = False
   def __repr__(self):
-    return """EXT %s Issued:%s (latest=%s) >>%s<< %s [%s]""" % (self.identifier,self.issued,self.isLatest,self.title,self.description,self.subject)
-    
+    return """EXT %s Issued:%s (latest=%s) >>%s<< %s [%s]""" % (self.identifier, self.issued, self.isLatest, self.title, self.description, self.subject)
+
 class Vocabulary:
   def __init__(self):
     self.identifier = None
@@ -35,12 +37,9 @@ class Vocabulary:
     self.description = None
     self.subject = None
     self.issued = None
-    self.isLatest=False
+    self.isLatest = False
   def __repr__(self):
-    return """VOC %s Issued:%s (latest=%s) >>%s<< %s [%s] """ % (self.identifier,self.issued,self.isLatest,self.title,self.description,self.subject)
-
-class UrlOpener(FancyURLopener):
-  version = 'GBIF sync extensions'
+    return """VOC %s Issued:%s (latest=%s) >>%s<< %s [%s] """ % (self.identifier, self.issued, self.isLatest, self.title, self.description, self.subject)
 
 def writeExtensions(dir, urls):
   f = open(dir + 'extensions.json', 'w')
@@ -53,29 +52,29 @@ def writeVocabs(dir, urls):
   f.close()
 
 def processUrls(fp, urls, rootElement):
-  """Retrieve a list of objects by their url, sort them by their issued 
-     date, update each object indicating if it is the latest issued or 
-     not, and write each object to the JSON file"""
+  """Retrieve a list of objects by their URL, sort them by their issue
+     date, update each object indicating if it is the latest issued or
+     not, and write each object to the JSON file."""
   fp.write('{"%s":[\n' % rootElement)
-  allObjects = [] 
+  allObjects = []
   for url in urls:
-    print "Processing %s" % url
+    print("Processing %s" % url)
     obj = parseUrl(url)
     if obj != None:
-        if obj.identifier != None:
-            allObjects.append(obj) 
-        else:
-            print "Missing identifier in %s. Ignore" % url
-  # sort by issued date, starting with newest dates
+      if obj.identifier != None:
+        allObjects.append(obj)
+      else:
+        print("Missing identifier in %s. Ignore" % url)
+  # sort by issued date, starting with newest
   allObjects = sorted(allObjects, key=getIssuedDate, reverse=True)
   # iterate through objects and indicate whether it is the latest or not
-  identifiers = [] 
+  identifiers = []
   for obj in allObjects:
     if (obj.identifier is not None and obj.identifier not in identifiers):
-      identifiers.append(obj.identifier) 
+      identifiers.append(obj.identifier)
       obj.isLatest=True
     else:
-      print 'The extension or vocabulary with URL %s issued %s is deprecated or superseded by one in production' % (obj.url, obj.issued)
+      print("The extension or vocabulary with URL %s issued %s is deprecated or superseded by one in production" % (obj.url, obj.issued))
   # write each object to the JSON file
   first = True;
   for obj in allObjects:
@@ -107,48 +106,49 @@ def parseUrl(url):
      URLs beginning http://rs.gbif.org are instead retrieved
      relative to this script."""
   try:
-    latestUrl = url.replace('http://rs.gbif.org/', RS_BASE)
-    f = UrlOpener().open(latestUrl)
+    latestUrl = url.replace('http://rs.gbif.org/', "file://"+RS_BASE)
     tree = ElementTree()
-    tree.parse(f)
-    f.close()
+    with urllib.request.urlopen(latestUrl) as response:
+      tree.parse(response)
+      response.close()
     doc = tree.getroot()
-    if (doc.tag=="{%s}extension"%NS_EXT):
-      obj=Extension()
-      obj.identifier=doc.attrib.get('rowType')
+    if (doc.tag == "{%s}extension"%NS_EXT):
+      obj = Extension()
+      obj.identifier = doc.attrib.get('rowType')
     else:
-      obj=Vocabulary()
-      obj.identifier=doc.attrib.get('{%s}URI'%NS_DC)
-    obj.url=url
-    obj.title=doc.attrib.get('{%s}title'%NS_DC)
-    obj.description=doc.attrib.get('{%s}description'%NS_DC)
-    obj.subject=doc.attrib.get('{%s}subject'%NS_DC)
+      obj = Vocabulary()
+      obj.identifier = doc.attrib.get('{%s}URI'%NS_DC)
+    obj.url = url
+    obj.title = doc.attrib.get('{%s}title'%NS_DC)
+    obj.description = doc.attrib.get('{%s}description'%NS_DC)
+    obj.subject = doc.attrib.get('{%s}subject'%NS_DC)
     # convert YYYY-MM-DD string date into datetime.date object
-    strDate=doc.attrib.get('{%s}issued'%NS_DC) 
+    strDate = doc.attrib.get('{%s}issued'%NS_DC)
     if (strDate is not None):
-      obj.issued=datetime.datetime.strptime(strDate, "%Y-%m-%d").date()
+      obj.issued = datetime.datetime.strptime(strDate, "%Y-%m-%d").date()
     return obj
   except:
-    print "Oops, cant parse url %s" % url
-    print '-'*60
-    traceback.print_exc(file=sys.stdout)
-    print '-'*60
+    print("Oops, cant parse URL %s" % url)
+    print("-"*60)
+    traceback.print_exc(file = sys.stdout)
+    print("-"*60)
+    exit(1)
     return None
-  
+
 
 def listExtensions(basedir, baseurl):
   urls = []
-  print "WALK DIR "+basedir
+  print("WALK DIR "+basedir)
   for fn in os.listdir(basedir):
     if fn.startswith("."):
       continue
-    p=os.path.join(basedir,fn)
+    p = os.path.join(basedir,fn)
     if os.path.isdir(p):
       urls.extend( listExtensions(basedir+fn+"/", baseurl+fn+"/") )
     else:
       if (fn.lower().endswith(".xml")):
         url = baseurl+fn
-        print " found extension at "+url
+        print(" found extension at "+url)
         urls.append(url)
   return urls
 
@@ -157,37 +157,37 @@ def listExternal(basedir):
 
 def listVocabularies(basedir, baseurl):
   urls = []
-  print "WALK DIR "+basedir
+  print("WALK DIR "+basedir)
   for fn in os.listdir(basedir):
     if fn.startswith("."):
       continue
-    p=os.path.join(basedir,fn)
+    p = os.path.join(basedir,fn)
     if os.path.isdir(p):
       urls.extend( listVocabularies(basedir+fn+"/", baseurl+fn+"/") )
     else:
       if (fn.lower().endswith(".xml")):
         url = baseurl+fn
-        print " found vocabulary at "+url
+        print(" found vocabulary at "+url)
         urls.append(url)
   return urls
-  
+
 if __name__ ==  "__main__":
-  print 'LOCATED RS.GBIF.ORG FILESYSTEM AT: '+RS_BASE
-  
-  print 'UPDATE PRODUCTION EXTENSION FILE'
-  externalProd=listExternal(RS_BASE+"extension/")
+  print("LOCATED RS.GBIF.ORG FILESYSTEM AT: "+RS_BASE)
+
+  print("UPDATE PRODUCTION EXTENSION FILE")
+  externalProd = listExternal(RS_BASE+"extension/")
   urlsCore = listExtensions(RS_BASE+"core/","http://rs.gbif.org/core/")
-  urlsExt  = listExtensions(RS_BASE+"extension/","http://rs.gbif.org/extension/")
+  urlsExt = listExtensions(RS_BASE+"extension/","http://rs.gbif.org/extension/")
   writeExtensions(RS_BASE, urlsCore+urlsExt+externalProd)
-  print 'UPDATE PRODUCTION VOCABULARY FILE'
+  print("UPDATE PRODUCTION VOCABULARY FILE")
   urlsVoc = listVocabularies(RS_BASE+"vocabulary/","http://rs.gbif.org/vocabulary/")
   writeVocabs(RS_BASE, urlsVoc)
 
-  print 'UPDATE SANDBOX EXTENSION FILE'
+  print("UPDATE SANDBOX EXTENSION FILE")
   externalDev=listExternal(RS_BASE+"sandbox/extension/")
   urlsSandbox = listExtensions(RS_BASE+"sandbox/extension/","http://rs.gbif.org/sandbox/extension/")
   urlsSandboxCore = listExtensions(RS_BASE+"sandbox/core/","http://rs.gbif.org/sandbox/core/")
-  writeExtensions(RS_BASE+'sandbox/', urlsCore+urlsExt+urlsSandbox+externalProd+externalDev+urlsSandboxCore)  
-  print 'UPDATE SANDBOX VOCABULARY FILE'
+  writeExtensions(RS_BASE+"sandbox/", urlsCore+urlsExt+urlsSandbox+externalProd+externalDev+urlsSandboxCore)
+  print("UPDATE SANDBOX VOCABULARY FILE")
   urlsVoc2 = listVocabularies(RS_BASE+"sandbox/vocabulary/","http://rs.gbif.org/sandbox/vocabulary/")
-  writeVocabs(RS_BASE+'sandbox/', urlsVoc+urlsVoc2)
+  writeVocabs(RS_BASE+"sandbox/", urlsVoc+urlsVoc2)

--- a/sync-extensions.py
+++ b/sync-extensions.py
@@ -35,6 +35,10 @@ HTML_EXTENSION_TEMPLATE_HEADER = Template("""
                 background: rgba(67%, 67%, 67%, 50%);
                 padding: 0.5em 0 0 0.5em;
             }
+            .definition:target {
+                background: rgba(90%, 100%, 100%, 50%);
+                outline: 2px solid rgba(90%, 100%, 100%, 100%);
+            }
             .definition .title {
                 margin-left: 2rem;
                 font-weight: bold;
@@ -72,8 +76,7 @@ HTML_EXTENSION_TEMPLATE_HEADER = Template("""
 """)
 
 HTML_EXTENSION_TEMPLATE_ENTRY = Template("""
-        <a id="$identifier"></a>
-        <div class="definition">
+        <div id="$identifier" class="definition">
             <div class="title">
                 <a href="$url">$title</a>
             </div>
@@ -183,35 +186,35 @@ def processUrls(fp, html, urls, env, rootElement):
 
     # Write Apache HTTPD asis files to allow redirects like https://rs.gbif.org/terms/1.0/Distribution → https://rs.gbif.org/extension/gbif/1.0/distribution_2022-02-02.xml
     if (obj.isLatest and obj.identifier.startswith("http://rs.gbif.org/") and "#" not in obj.identifier):
-        if (env != PRODUCTION and not obj.identifier.startswith("http://rs.gbif.org/sandbox/")):
-            print("Refusing to create "+obj.identifier+" from the sandbox, adding sandbox/ to path")
-            path = RS_BASE + obj.identifier.replace("http://rs.gbif.org/", "sandbox/")
-        else:
-            path = RS_BASE + obj.identifier.replace("http://rs.gbif.org/", "")
-        # Some identifiers end with /, index.asis will be served
-        if (path.endswith("/")):
-            path = path + "index"
-        asisFile = path + ".asis"
-        asisDir = os.path.dirname(asisFile)
-        if not os.path.isdir(asisDir):
-            os.makedirs(asisDir)
-        a = open(asisFile, 'w')
-        a.write(ASIS_TEMPLATE.substitute(location=obj.url.replace("http://rs.gbif.org", "https://rs.gbif.org"), contentType='text/xml'))
-        a.close()
+      if (env != PRODUCTION and not obj.identifier.startswith("http://rs.gbif.org/sandbox/")):
+        print("Refusing to create "+obj.identifier+" from the sandbox, adding sandbox/ to path")
+        path = RS_BASE + obj.identifier.replace("http://rs.gbif.org/", "sandbox/")
+      else:
+        path = RS_BASE + obj.identifier.replace("http://rs.gbif.org/", "")
+      # Some identifiers end with /, index.asis will be served
+      if (path.endswith("/")):
+        path = path + "index"
+      asisFile = path + ".asis"
+      asisDir = os.path.dirname(asisFile)
+      if not os.path.isdir(asisDir):
+        os.makedirs(asisDir)
+      a = open(asisFile, 'w')
+      a.write(ASIS_TEMPLATE.substitute(location=obj.url.replace("http://rs.gbif.org", "https://rs.gbif-uat.org"), contentType='text/xml'))
+      a.close()
 
     # Write HTML extensions list
     if (obj.isLatest and html):
-        t = dict(
-            identifier=obj.identifier,
-            url=obj.url,
-            title=obj.title,
-            description=obj.description,
-            name=obj.name,
-            namespace=obj.namespace,
-            issued=obj.issued,
-            subject=obj.subject,
-        )
-        html.write(HTML_EXTENSION_TEMPLATE_ENTRY.substitute(t))
+      t = dict(
+        identifier=obj.identifier,
+        url=obj.url,
+        title=obj.title,
+        description=obj.description,
+        name=obj.name,
+        namespace=obj.namespace,
+        issued=obj.issued,
+        subject=obj.subject,
+      )
+      html.write(HTML_EXTENSION_TEMPLATE_ENTRY.substitute(t))
 
     # Write JSON extensions list
     # name and namespace are used in the HTML list, but not the JSON.
@@ -223,7 +226,7 @@ def processUrls(fp, html, urls, env, rootElement):
 
   fp.write('\n]}')
   if (html):
-      html.write(HTML_EXTENSION_TEMPLATE_FOOTER.substitute())
+    html.write(HTML_EXTENSION_TEMPLATE_FOOTER.substitute())
 
   return allObjects
 

--- a/sync-extensions.py
+++ b/sync-extensions.py
@@ -36,7 +36,6 @@ HTML_EXTENSION_TEMPLATE_HEADER = Template("""
                 padding: 0.5em 0 0 0.5em;
             }
             .definition .title {
-                margin-top: 0.3em;
                 margin-left: 2rem;
                 font-weight: bold;
                 font-size: 1.2em;
@@ -55,6 +54,13 @@ HTML_EXTENSION_TEMPLATE_HEADER = Template("""
         </style>
     </head>
     <body>
+        <nav>
+            <ul>
+                <li><img src="/style/logo-gbif-white.svg" width="67" height="28"/></li>
+                <li><a href="/">Repository of Schemas</a></li>
+            </ul>
+        </nav>
+
         <header>
             <img src="/style/logo-gbif.svg" alt="GBIF" width="115" height="46"/>
             <h1>Registered Extensions</h1>


### PR DESCRIPTION
See https://rs.gbif-uat.org/ (first entry in the list added).

https://rs.gbif-uat.org/extensions.html — the list itself, excluding sandbox extensions.

https://rs.gbif-uat.org/sandbox/extensions.html — the list including sandbox extensions.

URLs like https://tools.gbif.org/dwca-validator/extension.do?id=dwc:Taxon will (later) redirect to https://rs.gbif-uat.org/extensions.html#http://rs.tdwg.org/dwc/terms/Taxon, which is hopefully clear enough. I think that's the best we can do with a static site.

Except the GBIF namespace ones, like http://rs.gbif.org/terms/1.0/Distribution, will now redirect to the latest schema as with http://rs.gbif-uat.org/terms/1.0/Distribution

Also includes conversion to Python 3 and improvements to styling.

Closes #87.